### PR TITLE
fix(code): code hydration error

### DIFF
--- a/packages/react-notion-x/src/third-party/code.tsx
+++ b/packages/react-notion-x/src/third-party/code.tsx
@@ -84,7 +84,11 @@ export function Code({
 
   return (
     <>
-      <pre className={cs('notion-code', className)}>
+      <pre
+        className={cs('notion-code', `language-${language}`, className)}
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={0}
+      >
         <div className='notion-code-copy'>
           {copyButton}
 


### PR DESCRIPTION
- prismjs is under the hood, it addes language and tabIndex attributes to pre tag but the ssr results doesn't have these, so hydration error occures.

#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
